### PR TITLE
bump runtime to kde 5.14

### DIFF
--- a/io.gitlab.evtest_qt.evtest_qt.json
+++ b/io.gitlab.evtest_qt.evtest_qt.json
@@ -1,13 +1,14 @@
 {
     "app-id": "io.gitlab.evtest_qt.evtest_qt",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.11",
+    "runtime-version": "5.14",
     "sdk": "org.kde.Sdk",
     "rename-appdata-file": "evtest-qt.appdata.xml",
     "rename-icon": "evtest-qt",
     "rename-desktop-file": "evtest-qt.desktop",
     "finish-args": [
         "--device=all",
+        "--env=QT_QPA_PLATFORM=xcb",
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland"
@@ -17,8 +18,7 @@
             "name": "evtest-qt",
             "buildsystem": "cmake-ninja",
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DCMAKE_INSTALL_PREFIX:PATH=/app"
+                "-DCMAKE_BUILD_TYPE=Release"
             ],
             "sources": [
                 {


### PR DESCRIPTION
This is a lazy runtime bump to 5.14. I want to get rid of the 5.11 runtime and this is the only app dependent on it in my system.  
Tested with a USB keyboard and a Bluetooth 8BitDo controller on a system with Sway Wayland compositor, both running as native Wayland client and through XWayland.  
At least with Sway, when running as a native Wayland client, something strange is happening with the GUI on an input device switch.  I don't want to bother debugging this ATM, so I just forced running through XWayland the environment variable.  
With XWayland it looks like everything is working as it should.  
Note that with the 5.11 runtime the GUI doesn't even make an appearance on Wayland without forcing to use XWayland.