### PR TITLE
Update KDE runtime to 5.15

### DIFF
--- a/io.gitlab.evtest_qt.evtest_qt.json
+++ b/io.gitlab.evtest_qt.evtest_qt.json
@@ -1,15 +1,15 @@
 {
     "app-id": "io.gitlab.evtest_qt.evtest_qt",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.14",
+    "runtime-version": "5.15",
     "sdk": "org.kde.Sdk",
     "rename-appdata-file": "evtest-qt.appdata.xml",
     "rename-icon": "evtest-qt",
     "rename-desktop-file": "evtest-qt.desktop",
     "finish-args": [
         "--device=all",
-        "--env=QT_QPA_PLATFORM=xcb",
         "--share=ipc",
+        "--socket=fallback-x11",
         "--socket=x11",
         "--socket=wayland"
     ],


### PR DESCRIPTION
* Bump runtime to the latest 5.15 version.

* Remove the preset QT_QPA_PLATFORM environment.
  This is a workaround for minor graphical glitch on Sway due where the
  app UI being automatically resized on every input device selection but
  the Sway window tiled container can't resize.
  I've tested this on the latest Fedora 34 beta with Gnome 40 and it's
  working as expected.
  As this a specific issue with Sway, and a minor one, then it's better
  not force this for all users.
  Sway users should be aware of such issues and competent enough to
  override this.

* Add fallback-x11 socket permission
  The xcb backend is not being forced anymore so app should use
  fallback-x11 to avoid giving access to xserver if Wayland is
  available on the host.
  x11 socket is kept to avoid breaking xserver access with older than
  0.11.3 flatpak releases.
  The fallback-x11 has a higher priority than x11 so it should work as
  expected on a Flatpak version that support this.